### PR TITLE
Add test for async-action to catch error

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -667,6 +667,31 @@ test("createAsyncAction", done => {
   }, 25);
 });
 
+test("createAsyncAction should catch error", (done) => {
+  const errorThrowingFunc = async () => {
+    await new Promise((res) => setTimeout(res, 50));
+    throw new Error("Expect this to be caught");
+  };
+
+  const [command, loading, error] = createAsyncAction({
+    id: "my-action",
+    async: (_store, _status) => async () => {
+      await errorThrowingFunc();
+    },
+  });
+  command();
+  expect(error()).toBeFalsy();
+  setTimeout(() => {
+    try {
+      expect(error()).toBeTruthy();
+      expect(loading()).toBeFalsy();
+      done();
+    } catch (e) {
+      done.fail(e);
+    }
+  }, 75);
+});
+
 test("createAsyncAction debounced", done => {
   const state = {
     name: "mark"


### PR DESCRIPTION
I was seeing an error that I thought async-action should have caught, so I wrote a test to confirm behavior. I think it might be good to add to main test suite, so here you go!
