### PR TITLE
Correct getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const getEmployees = searchText => {
   return new Promise(resolve => {
     const database = ["Mark Metzger", "Steve Miller"];
     setTimeout(() => {
-      resolve(database.filter(name => searchText.includes(name)));
+      resolve(database.filter(name => name.includes(searchText)));
     }, 1000);
   });
 };


### PR DESCRIPTION
I gave the getting started example a try and spent a few minutes debugging a non-existent problem with my application.

The actual issue is that the example seems to have the search filtering backwards. I.e. it looks for the items from the database in the search term instead of the other way around. So `'Mark'` from `['Mark Metzger', 'Steve Miller']` would return `[]` instead of `['Mark Metzger']`.

This PR corrects that to look for the search term in in each item in the "database".